### PR TITLE
Update setup.py naming

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 
 setup(
-    name='__dummy_package',
+    name='pre-commit-mirrors-pep257',
     version='0.0.1',
     install_requires=['pep257==0.7.0'],
 )


### PR DESCRIPTION
There was an issue with package naming on some OS X machines while using pre-commit command:

`error: Invalid distribution name or version syntax: -dummy-package-0.0.1`

Changing "__dummy_package" to another name, like for example 'pre-commit-mirrors-pep257' fixed this error.
