### PR TITLE
Fix #5 -- add .pre-commit-hooks.yaml for pre-commit update

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+-   id: pep257
+    name: pep257
+    entry: pep257
+    language: python
+    files: \.py$


### PR DESCRIPTION
Greetings, @FalconSocial!

As mentioned here: https://github.com/FalconSocial/pre-commit-mirrors-pep257/issues/5
We need to add `.pre-commit-hooks.yaml` for newer pre-commit versions.
And it would be good to keep old `hooks.yaml` for some time.

And thank you for the package. :)